### PR TITLE
Update the name and repository to use grock.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,8 +12,8 @@
     <div id="app"></div>
     <script>
       window.$docsify = {
-        name: 'REPONAME',
-        repo: 'USERNAME/REPONAME',
+        name: 'course-connect-the-dots',
+        repo: 'grock/course-connect-the-dots',
         homepage: 'index.html',
         loadSidebar: true
       }


### PR DESCRIPTION
Update the name and repository to use grock instead of a default values so that GitHub Pages can be enabled.